### PR TITLE
* When merging the objects we are inserting another key called (depen…

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -5,6 +5,7 @@ import {
   orderProperties,
   retrieveSchema,
   getDefaultRegistry,
+  clearDependencies,
 } from "../../utils";
 
 function DefaultObjectFieldTemplate(props) {
@@ -51,8 +52,14 @@ class ObjectField extends Component {
 
   onPropertyChange = name => {
     return (value, errorSchema) => {
-      const newFormData = { ...this.props.formData, [name]: value };
-      this.props.onChange(
+      const { formData, schema, onChange } = this.props;
+      let clearedFormData = clearDependencies(
+        formData,
+        retrieveSchema(schema, undefined, formData),
+        name
+      );
+      const newFormData = { ...clearedFormData, [name]: value };
+      onChange(
         newFormData,
         errorSchema &&
           this.props.errorSchema && {

--- a/src/utils.js
+++ b/src/utils.js
@@ -240,6 +240,9 @@ export function mergeObjects(obj1, obj2, concatArrays = false, dependencyKey) {
         }
       });
       acc[key] = right;
+      acc[key].dependsOn = Object.assign({}, acc[key].dependsOn, {
+        [dependencyKey]: true,
+      });
       Object.keys(tempObj).forEach(property => {
         acc[property] = tempObj[property];
       });
@@ -248,6 +251,20 @@ export function mergeObjects(obj1, obj2, concatArrays = false, dependencyKey) {
     }
     return acc;
   }, acc);
+}
+
+export function clearDependencies(formData = {}, schema, name) {
+  let clearedFormData = Object.assign({}, formData);
+  let properties = schema.properties;
+  Object.keys(properties).forEach(property => {
+    if (
+      properties[property].hasOwnProperty("dependsOn") &&
+      properties[property].dependsOn.hasOwnProperty(name)
+    ) {
+      delete clearedFormData[property];
+    }
+  });
+  return clearedFormData;
 }
 
 export function asNumber(value) {


### PR DESCRIPTION
* When merging the objects we are inserting another key called (dependsOn), which contains an object of every fields in the form data that this field is depends on.
* Then, in the function onPropertyChange, we are passing the current formData with the changed field to the function clearDependencies which removes the keys (from the formData replication) that depends on the changed field and returns the new formData object to the onPropertyChange function.


### Reasons for making this change

The data of the dependent fields is still in the formData object even though they are unselected.